### PR TITLE
add support for client cert params

### DIFF
--- a/jetstream/provider.go
+++ b/jetstream/provider.go
@@ -64,6 +64,26 @@ func Provider() terraform.ResourceProvider {
 							Optional:    true,
 							Description: "The root CA (file) content, in PEM format. Needed when the NATS server has TLS enabled with an unknown root CA",
 						},
+						"cert_file": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Path to client cert file (in PEM format). Needed when NATS server is configured to verify client certificate",
+						},
+						"cert_file_data": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The cert file content (in PEM format). Needed when NATS server is configured to verify client certificate",
+						},
+						"key_file": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Path to client key file (in PEM format). Needed when NATS server is configured to verify client certificate",
+						},
+						"key_file_data": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The key file content (in PEM format). Needed when NATS server is configured to verify client certificate",
+						},
 					},
 				},
 			},

--- a/jetstream/provider_test.go
+++ b/jetstream/provider_test.go
@@ -62,7 +62,7 @@ func createJSServer(t *testing.T) (srv *server.Server) {
 	return srv
 }
 
-func createJSTLSServer(t *testing.T) (srv *server.Server) {
+func createJSTLSServer(t *testing.T, verifyClientCert bool) (srv *server.Server) {
 	t.Helper()
 
 	dir, err := os.MkdirTemp("", "")
@@ -79,6 +79,7 @@ func createJSTLSServer(t *testing.T) (srv *server.Server) {
 		JetStream: true,
 		TLS:       true,
 		TLSConfig: tlsConfig,
+		TLSVerify: verifyClientCert,
 	})
 	checkErr(t, err, "could not start js server: %v", err)
 

--- a/jetstream/provider_tls_test.go
+++ b/jetstream/provider_tls_test.go
@@ -39,8 +39,46 @@ resource "jetstream_stream" "test" {
 }
 `
 
+const testClientTLSConfig_file_data = `
+provider "jetstream" {
+  servers = "%s"
+  tls {
+    ca_file_data = <<EOT
+%s
+    EOT
+    cert_file_data = <<EOT
+%s
+    EOT
+    key_file_data = <<EOT
+%s
+    EOT
+  }
+}
+
+resource "jetstream_stream" "test" {
+  name     = "TEST"
+  subjects = ["TEST.*"]
+}
+`
+
+const testClientTLSConfig_file = `
+provider "jetstream" {
+  servers = "%s"
+  tls {
+    ca_file = "%s"
+    cert_file = "%s"
+    key_file = "%s"
+  }
+}
+
+resource "jetstream_stream" "test" {
+  name     = "TEST"
+  subjects = ["TEST.*"]
+}
+`
+
 func TestProviderWithTLSFromData(t *testing.T) {
-	srv := createJSTLSServer(t)
+	srv := createJSTLSServer(t, false)
 	defer srv.Shutdown()
 
 	caFile, cleanup, err := newTempPEMFile(caPEM)
@@ -75,7 +113,7 @@ func TestProviderWithTLSFromData(t *testing.T) {
 }
 
 func TestProviderWithTLSFromFile(t *testing.T) {
-	srv := createJSTLSServer(t)
+	srv := createJSTLSServer(t, false)
 	defer srv.Shutdown()
 
 	caFile, cleanup, err := newTempPEMFile(caPEM)
@@ -100,6 +138,98 @@ func TestProviderWithTLSFromFile(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(testTLSConfig_file, nc.ConnectedUrl(), caFile),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamExist(t, mgr, "TEST"),
+				),
+			},
+		},
+	})
+}
+
+func TestProviderWithClientTLSFromData(t *testing.T) {
+	srv := createJSTLSServer(t, true)
+	defer srv.Shutdown()
+
+	caFile, cleanupCa, err := newTempPEMFile(caPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp CA PEM: %s", err)
+	}
+	defer cleanupCa()
+
+	certFile, cleanupCert, err := newTempPEMFile(certPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp cert PEM: %s", err)
+	}
+	defer cleanupCert()
+
+	keyFile, cleanupKey, err := newTempPEMFile(keyPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp key PEM: %s", err)
+	}
+	defer cleanupKey()
+
+	nc, err := nats.Connect(srv.ClientURL(), nats.RootCAs(caFile), nats.ClientCert(certFile, keyFile))
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	defer nc.Close()
+
+	mgr, err := jsm.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testJsProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testClientTLSConfig_file_data, nc.ConnectedUrl(), caPEM, certPEM, keyPEM),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamExist(t, mgr, "TEST"),
+				),
+			},
+		},
+	})
+}
+
+func TestProviderWithClientTLSFromFile(t *testing.T) {
+	srv := createJSTLSServer(t, true)
+	defer srv.Shutdown()
+
+	caFile, cleanupCa, err := newTempPEMFile(caPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp CA PEM: %s", err)
+	}
+	defer cleanupCa()
+
+	certFile, cleanupCert, err := newTempPEMFile(certPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp cert PEM: %s", err)
+	}
+	defer cleanupCert()
+
+	keyFile, cleanupKey, err := newTempPEMFile(keyPEM)
+	if err != nil {
+		t.Fatalf("failed to create temp key PEM: %s", err)
+	}
+	defer cleanupKey()
+
+	nc, err := nats.Connect(srv.ClientURL(), nats.RootCAs(caFile), nats.ClientCert(certFile, keyFile))
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	defer nc.Close()
+
+	mgr, err := jsm.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testJsProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testClientTLSConfig_file, nc.ConnectedUrl(), caFile, certFile, keyFile),
 				Check: resource.ComposeTestCheckFunc(
 					testStreamExist(t, mgr, "TEST"),
 				),


### PR DESCRIPTION
this PR adds support for specifying client certificate params, corresponding to `--tlscert` and `--tlskey` on the NATS cli.