### PR TITLE
add missing permission to create KV buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,28 +31,29 @@ A locked down user that can only admin JetStream but not retrieve any data store
 │ Issuer ID            │ AARRII4JZYJB3WYECBTMU6WSST2SUZ7SN7PWNSDWQTYVPMXQHDA3WXZ7 │
 │ Issued               │ 2020-03-11 10:37:29 UTC                                  │
 │ Expires              │ 2020-04-11 10:37:29 UTC                                  │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Pub Allow            │ $JS.API.STREAM.CREATE.*                                  │
-│                      │ $JS.API.STREAM.UPDATE.*                                  │
-│                      │ $JS.API.STREAM.DELETE.*                                  │
-│                      │ $JS.API.STREAM.INFO.*                                    │
-│                      │ $JS.API.STREAM.LIST                                      |
-│                      │ $JS.API.STREAM.NAMES                                     |
-│                      │ $JS.API.CONSUMER.DURABLE.CREATE.*.*                      |
-│                      │ $JS.API.CONSUMER.DELETE.*.*                              |
-│                      │ $JS.API.CONSUMER.INFO.*.*                                |
++----------------------+----------------------------------------------------------+
+| Pub Allow            | $JS.API.CONSUMER.DELETE.*.*                              |
+|                      | $JS.API.CONSUMER.DURABLE.CREATE.*.*                      |
+|                      | $JS.API.CONSUMER.INFO.*.*                                |
 |                      | $JS.API.CONSUMER.LIST.*                                  |
 |                      | $JS.API.CONSUMER.NAMES.*                                 |
-│                      │ $JS.API.STREAM.TEMPLATE.>                                │
-│ Sub Allow            │ _INBOX.>                                                 │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Response Permissions │ Not Set                                                  │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Max Messages         │ Unlimited                                                │
-│ Max Msg Payload      │ Unlimited                                                │
-│ Network Src          │ Any                                                      │
-│ Time                 │ Any                                                      │
-╰──────────────────────┴──────────────────────────────────────────────────────────╯
+|                      | $JS.API.INFO                                             |
+|                      | $JS.API.STREAM.CREATE.*                                  |
+|                      | $JS.API.STREAM.DELETE.*                                  |
+|                      | $JS.API.STREAM.INFO.*                                    |
+|                      | $JS.API.STREAM.LIST                                      |
+|                      | $JS.API.STREAM.NAMES                                     |
+|                      | $JS.API.STREAM.TEMPLATE.>                                |
+|                      | $JS.API.STREAM.UPDATE.*                                  |
+| Sub Allow            | _INBOX.>                                                 |
+| Response Permissions | Not Set                                                  |
++----------------------+----------------------------------------------------------+
+| Max Msg Payload      | Unlimited                                                |
+| Max Data             | Unlimited                                                |
+| Max Subs             | Unlimited                                                |
+| Network Src          | Any                                                      |
+| Time                 | Any                                                      |
++----------------------+----------------------------------------------------------+
 ```
 
 Here's a command to create this using `nsc`, note replace the `DemoAccount` and `1M` strings with your account name and desired expiry time:
@@ -61,18 +62,19 @@ Here's a command to create this using `nsc`, note replace the `DemoAccount` and 
 $ nsc add user -a DemoAccount
 --expiry 1M \
 --name ngs_jetstream_admin \
+--allow-pub '$JS.API.CONSUMER.DELETE.*.*' \
+--allow-pub '$JS.API.CONSUMER.DURABLE.CREATE.*.*' \
+--allow-pub '$JS.API.CONSUMER.INFO.*.*' \
+--allow-pub '$JS.API.CONSUMER.LIST.*' \
+--allow-pub '$JS.API.CONSUMER.NAMES.*' \
+--allow-pub '$JS.API.INFO' \
 --allow-pub '$JS.API.STREAM.CREATE.*' \
---allow-pub '$JS.API.STREAM.UPDATE.*' \
 --allow-pub '$JS.API.STREAM.DELETE.*' \
 --allow-pub '$JS.API.STREAM.INFO.*' \
 --allow-pub '$JS.API.STREAM.LIST' \
 --allow-pub '$JS.API.STREAM.NAMES' \
---allow-pub '$JS.API.CONSUMER.DURABLE.CREATE.*.*' \
---allow-pub '$JS.API.CONSUMER.DELETE.*.*' \
---allow-pub '$JS.API.CONSUMER.INFO.*.*' \
---allow-pub '$JS.API.CONSUMER.LIST.*' \
---allow-pub '$JS.API.CONSUMER.NAMES.*' \
 --allow-pub '$JS.API.STREAM.TEMPLATE.>' \
+--allow-pub '$JS.API.STREAM.UPDATE.*' \
 --allow-sub '_INBOX.>'
 ```
 

--- a/docs/guides/setup.md
+++ b/docs/guides/setup.md
@@ -33,28 +33,29 @@ A locked down user that can only admin JetStream but not retrieve any data store
 │ Issuer ID            │ AARRII4JZYJB3WYECBTMU6WSST2SUZ7SN7PWNSDWQTYVPMXQHDA3WXZ7 │
 │ Issued               │ 2020-03-11 10:37:29 UTC                                  │
 │ Expires              │ 2020-04-11 10:37:29 UTC                                  │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Pub Allow            │ $JS.API.STREAM.CREATE.*                                  │
-│                      │ $JS.API.STREAM.UPDATE.*                                  │
-│                      │ $JS.API.STREAM.DELETE.*                                  │
-│                      │ $JS.API.STREAM.INFO.*                                    │
-│                      │ $JS.API.STREAM.LIST                                      |
-│                      │ $JS.API.STREAM.NAMES                                     |
-│                      │ $JS.API.CONSUMER.DURABLE.CREATE.*.*                      |
-│                      │ $JS.API.CONSUMER.DELETE.*.*                              |
-│                      │ $JS.API.CONSUMER.INFO.*.*                                |
++----------------------+----------------------------------------------------------+
+| Pub Allow            | $JS.API.CONSUMER.DELETE.*.*                              |
+|                      | $JS.API.CONSUMER.DURABLE.CREATE.*.*                      |
+|                      | $JS.API.CONSUMER.INFO.*.*                                |
 |                      | $JS.API.CONSUMER.LIST.*                                  |
 |                      | $JS.API.CONSUMER.NAMES.*                                 |
-│                      │ $JS.API.STREAM.TEMPLATE.>                                │
-│ Sub Allow            │ _INBOX.>                                                 │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Response Permissions │ Not Set                                                  │
-├──────────────────────┼──────────────────────────────────────────────────────────┤
-│ Max Messages         │ Unlimited                                                │
-│ Max Msg Payload      │ Unlimited                                                │
-│ Network Src          │ Any                                                      │
-│ Time                 │ Any                                                      │
-╰──────────────────────┴──────────────────────────────────────────────────────────╯
+|                      | $JS.API.INFO                                             |
+|                      | $JS.API.STREAM.CREATE.*                                  |
+|                      | $JS.API.STREAM.DELETE.*                                  |
+|                      | $JS.API.STREAM.INFO.*                                    |
+|                      | $JS.API.STREAM.LIST                                      |
+|                      | $JS.API.STREAM.NAMES                                     |
+|                      | $JS.API.STREAM.TEMPLATE.>                                |
+|                      | $JS.API.STREAM.UPDATE.*                                  |
+| Sub Allow            | _INBOX.>                                                 |
+| Response Permissions | Not Set                                                  |
++----------------------+----------------------------------------------------------+
+| Max Msg Payload      | Unlimited                                                |
+| Max Data             | Unlimited                                                |
+| Max Subs             | Unlimited                                                |
+| Network Src          | Any                                                      |
+| Time                 | Any                                                      |
++----------------------+----------------------------------------------------------+
 ```
 
 Here's a command to create this using `nsc`, note replace the `DemoAccount` and `1M` strings with your account name and desired expiry time:
@@ -63,18 +64,19 @@ Here's a command to create this using `nsc`, note replace the `DemoAccount` and 
 $ nsc add user -a DemoAccount
 --expiry 1M \
 --name ngs_jetstream_admin \
+--allow-pub '$JS.API.CONSUMER.DELETE.*.*' \
+--allow-pub '$JS.API.CONSUMER.DURABLE.CREATE.*.*' \
+--allow-pub '$JS.API.CONSUMER.INFO.*.*' \
+--allow-pub '$JS.API.CONSUMER.LIST.*' \
+--allow-pub '$JS.API.CONSUMER.NAMES.*' \
+--allow-pub '$JS.API.INFO' \
 --allow-pub '$JS.API.STREAM.CREATE.*' \
---allow-pub '$JS.API.STREAM.UPDATE.*' \
 --allow-pub '$JS.API.STREAM.DELETE.*' \
 --allow-pub '$JS.API.STREAM.INFO.*' \
 --allow-pub '$JS.API.STREAM.LIST' \
 --allow-pub '$JS.API.STREAM.NAMES' \
---allow-pub '$JS.API.CONSUMER.DURABLE.CREATE.*.*' \
---allow-pub '$JS.API.CONSUMER.DELETE.*.*' \
---allow-pub '$JS.API.CONSUMER.INFO.*.*' \
---allow-pub '$JS.API.CONSUMER.LIST.*' \
---allow-pub '$JS.API.CONSUMER.NAMES.*' \
 --allow-pub '$JS.API.STREAM.TEMPLATE.>' \
+--allow-pub '$JS.API.STREAM.UPDATE.*' \
 --allow-sub '_INBOX.>'
 ```
 


### PR DESCRIPTION
The publish permission for `$JS.API.INFO` were missing in the README. They seem to be required for creating KV buckets. 
I added the missing permission and updated the `nsc describe user` output as well as the `nsc add user` command with parameters in the right order (as the CLI prints them today).

Without the permissions I received an error:

```
❯ TF_LOG=DEBUG terraform apply
2023-05-04T09:36:34.741+0200 [INFO]  Terraform version: 1.3.6
2023-05-04T09:36:34.741+0200 [DEBUG] using github.com/hashicorp/go-tfe v1.9.0
2023-05-04T09:36:34.741+0200 [DEBUG] using github.com/hashicorp/hcl/v2 v2.15.0
2023-05-04T09:36:34.741+0200 [DEBUG] using github.com/hashicorp/terraform-config-inspect v0.0.0-20210209133302-4fd17a0faac2
2023-05-04T09:36:34.741+0200 [DEBUG] using github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
2023-05-04T09:36:34.741+0200 [DEBUG] using github.com/zclconf/go-cty v1.12.1
2023-05-04T09:36:34.741+0200 [INFO]  Go runtime version: go1.19.3
2023-05-04T09:36:34.741+0200 [INFO]  CLI args: []string{"terraform", "apply"}
2023-05-04T09:36:34.741+0200 [DEBUG] Attempting to open CLI config file: /Users/arndtmx/.terraformrc
2023-05-04T09:36:34.741+0200 [DEBUG] File doesn't exist, but doesn't need to. Ignoring.
2023-05-04T09:36:34.741+0200 [DEBUG] ignoring non-existing provider search directory terraform.d/plugins
2023-05-04T09:36:34.741+0200 [DEBUG] ignoring non-existing provider search directory /Users/arndtmx/.terraform.d/plugins
2023-05-04T09:36:34.741+0200 [DEBUG] ignoring non-existing provider search directory /Users/arndtmx/Library/Application Support/io.terraform/plugins
2023-05-04T09:36:34.741+0200 [DEBUG] ignoring non-existing provider search directory /Library/Application Support/io.terraform/plugins
2023-05-04T09:36:34.741+0200 [INFO]  CLI command args: []string{"apply"}
2023-05-04T09:36:34.742+0200 [DEBUG] New state was assigned lineage "4e3302d6-005e-a782-0cfd-fd4a72f309e4"
2023-05-04T09:36:34.761+0200 [DEBUG] checking for provisioner in "."
2023-05-04T09:36:34.763+0200 [DEBUG] checking for provisioner in "/opt/homebrew/bin"
2023-05-04T09:36:34.764+0200 [INFO]  backend/local: starting Apply operation
2023-05-04T09:36:34.766+0200 [DEBUG] created provider logger: level=debug
2023-05-04T09:36:34.766+0200 [INFO]  provider: configuring client automatic mTLS
2023-05-04T09:36:34.777+0200 [DEBUG] provider: starting plugin: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 
args=[.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35]
2023-05-04T09:36:34.779+0200 [DEBUG] provider: plugin started: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8421
2023-05-04T09:36:34.779+0200 [DEBUG] provider: waiting for RPC address: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35
2023-05-04T09:36:34.788+0200 [INFO]  provider.terraform-provider-jetstream_v0.0.35: configuring server automatic mTLS: timestamp=2023-05-04T09:36:34.788+0200
2023-05-04T09:36:34.794+0200 [DEBUG] provider: using plugin: version=5
2023-05-04T09:36:34.794+0200 [DEBUG] provider.terraform-provider-jetstream_v0.0.35: plugin address: address=/var/folders/55/9t1x2vn93732wn08w_tf8z600000gq/T/plugin1205901189 network=unix timestamp=2023-05-04T09:36:34.794+0200
2023-05-04T09:36:34.800+0200 [DEBUG] No provider meta schema returned
2023-05-04T09:36:34.801+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2023-05-04T09:36:34.802+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8421
2023-05-04T09:36:34.802+0200 [DEBUG] provider: plugin exited
2023-05-04T09:36:34.802+0200 [DEBUG] Building and walking validate graph
2023-05-04T09:36:34.802+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG" (*terraform.NodeValidatableResource) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:34.802+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG" references: []
2023-05-04T09:36:34.802+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/nats-io/jetstream\"]" references: []
2023-05-04T09:36:34.802+0200 [DEBUG] Starting graph walk: walkValidate
2023-05-04T09:36:34.802+0200 [DEBUG] created provider logger: level=debug
2023-05-04T09:36:34.802+0200 [INFO]  provider: configuring client automatic mTLS
2023-05-04T09:36:34.806+0200 [DEBUG] provider: starting plugin: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 
args=[.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35]
2023-05-04T09:36:34.808+0200 [DEBUG] provider: plugin started: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8422
2023-05-04T09:36:34.808+0200 [DEBUG] provider: waiting for RPC address: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35
2023-05-04T09:36:34.817+0200 [INFO]  provider.terraform-provider-jetstream_v0.0.35: configuring server automatic mTLS: timestamp=2023-05-04T09:36:34.817+0200
2023-05-04T09:36:34.822+0200 [DEBUG] provider: using plugin: version=5
2023-05-04T09:36:34.822+0200 [DEBUG] provider.terraform-provider-jetstream_v0.0.35: plugin address: address=/var/folders/55/9t1x2vn93732wn08w_tf8z600000gq/T/plugin1453884505 network=unix timestamp=2023-05-04T09:36:34.822+0200
2023-05-04T09:36:34.828+0200 [DEBUG] No provider meta schema returned
2023-05-04T09:36:34.830+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2023-05-04T09:36:34.830+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8422
2023-05-04T09:36:34.830+0200 [DEBUG] provider: plugin exited
2023-05-04T09:36:34.830+0200 [INFO]  backend/local: apply calling Plan
2023-05-04T09:36:34.830+0200 [DEBUG] Building and walking plan graph for NormalMode
2023-05-04T09:36:34.830+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG (expand)" (*terraform.nodeExpandPlannableResource) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:34.831+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG (expand)" references: []
2023-05-04T09:36:34.831+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/nats-io/jetstream\"]" references: []
2023-05-04T09:36:34.831+0200 [DEBUG] Starting graph walk: walkPlan
2023-05-04T09:36:34.831+0200 [DEBUG] created provider logger: level=debug
2023-05-04T09:36:34.831+0200 [INFO]  provider: configuring client automatic mTLS
2023-05-04T09:36:34.834+0200 [DEBUG] provider: starting plugin: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 
args=[.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35]
2023-05-04T09:36:34.836+0200 [DEBUG] provider: plugin started: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8423
2023-05-04T09:36:34.836+0200 [DEBUG] provider: waiting for RPC address: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35
2023-05-04T09:36:34.844+0200 [INFO]  provider.terraform-provider-jetstream_v0.0.35: configuring server automatic mTLS: timestamp=2023-05-04T09:36:34.844+0200
2023-05-04T09:36:34.849+0200 [DEBUG] provider.terraform-provider-jetstream_v0.0.35: plugin address: address=/var/folders/55/9t1x2vn93732wn08w_tf8z600000gq/T/plugin2384501005 network=unix timestamp=2023-05-04T09:36:34.849+0200
2023-05-04T09:36:34.849+0200 [DEBUG] provider: using plugin: version=5
2023-05-04T09:36:34.855+0200 [DEBUG] No provider meta schema returned
2023-05-04T09:36:34.856+0200 [DEBUG] Resource instance state not found for node "jetstream_kv_bucket.CFG", instance jetstream_kv_bucket.CFG
2023-05-04T09:36:34.856+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG" references: []
2023-05-04T09:36:34.856+0200 [DEBUG] refresh: jetstream_kv_bucket.CFG: no state, so not refreshing
2023-05-04T09:36:34.857+0200 [WARN]  Provider "registry.terraform.io/nats-io/jetstream" produced an invalid plan for jetstream_kv_bucket.CFG, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .max_bucket_size: planned value cty.NumberIntVal(-1) for a non-computed attribute
      - .ttl: planned value cty.NumberIntVal(0) for a non-computed attribute
      - .max_value_size: planned value cty.NumberIntVal(-1) for a non-computed attribute
      - .replicas: planned value cty.NumberIntVal(1) for a non-computed attribute
2023-05-04T09:36:34.858+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2023-05-04T09:36:34.858+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8423
2023-05-04T09:36:34.858+0200 [DEBUG] provider: plugin exited
2023-05-04T09:36:34.858+0200 [DEBUG] building apply graph to check for errors
2023-05-04T09:36:34.858+0200 [DEBUG] Resource state not found for node "jetstream_kv_bucket.CFG", instance jetstream_kv_bucket.CFG
2023-05-04T09:36:34.858+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG" (*terraform.NodeApplyableResourceInstance) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:34.858+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:34.858+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG (expand)" references: []
2023-05-04T09:36:34.858+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG" references: []
2023-05-04T09:36:34.858+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/nats-io/jetstream\"]" references: []

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # jetstream_kv_bucket.CFG will be created
  + resource "jetstream_kv_bucket" "CFG" {
      + history         = 10
      + id              = (known after apply)
      + max_bucket_size = -1
      + max_value_size  = -1
      + name            = "CFG"
      + replicas        = 1
      + ttl             = 0
    }

Plan: 1 to add, 0 to change, 0 to destroy.
2023-05-04T09:36:34.859+0200 [DEBUG] command: asking for input: "\nDo you want to perform these actions?"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

2023-05-04T09:36:36.423+0200 [INFO]  backend/local: apply calling Apply
2023-05-04T09:36:36.423+0200 [DEBUG] Building and walking apply graph for NormalMode plan
2023-05-04T09:36:36.424+0200 [DEBUG] Resource state not found for node "jetstream_kv_bucket.CFG", instance jetstream_kv_bucket.CFG
2023-05-04T09:36:36.424+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG (expand)" (*terraform.nodeExpandApplyableResource) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:36.424+0200 [DEBUG] ProviderTransformer: "jetstream_kv_bucket.CFG" (*terraform.NodeApplyableResourceInstance) needs provider["registry.terraform.io/nats-io/jetstream"]
2023-05-04T09:36:36.424+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG (expand)" references: []
2023-05-04T09:36:36.424+0200 [DEBUG] ReferenceTransformer: "jetstream_kv_bucket.CFG" references: []
2023-05-04T09:36:36.424+0200 [DEBUG] ReferenceTransformer: "provider[\"registry.terraform.io/nats-io/jetstream\"]" references: []
2023-05-04T09:36:36.425+0200 [DEBUG] Starting graph walk: walkApply
2023-05-04T09:36:36.425+0200 [DEBUG] created provider logger: level=debug
2023-05-04T09:36:36.426+0200 [INFO]  provider: configuring client automatic mTLS
2023-05-04T09:36:36.437+0200 [DEBUG] provider: starting plugin: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 
args=[.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35]
2023-05-04T09:36:36.440+0200 [DEBUG] provider: plugin started: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8424
2023-05-04T09:36:36.440+0200 [DEBUG] provider: waiting for RPC address: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35
2023-05-04T09:36:36.458+0200 [INFO]  provider.terraform-provider-jetstream_v0.0.35: configuring server automatic mTLS: timestamp=2023-05-04T09:36:36.458+0200
2023-05-04T09:36:36.468+0200 [DEBUG] provider: using plugin: version=5
2023-05-04T09:36:36.468+0200 [DEBUG] provider.terraform-provider-jetstream_v0.0.35: plugin address: network=unix address=/var/folders/55/9t1x2vn93732wn08w_tf8z600000gq/T/plugin1224638551 timestamp=2023-05-04T09:36:36.468+0200
2023-05-04T09:36:36.477+0200 [DEBUG] No provider meta schema returned
2023-05-04T09:36:36.480+0200 [WARN]  Provider "registry.terraform.io/nats-io/jetstream" produced an invalid plan for jetstream_kv_bucket.CFG, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .max_value_size: planned value cty.NumberIntVal(-1) for a non-computed attribute
      - .replicas: planned value cty.NumberIntVal(1) for a non-computed attribute
      - .max_bucket_size: planned value cty.NumberIntVal(-1) for a non-computed attribute
      - .ttl: planned value cty.NumberIntVal(0) for a non-computed attribute
jetstream_kv_bucket.CFG: Creating...
2023-05-04T09:36:36.480+0200 [INFO]  Starting apply for jetstream_kv_bucket.CFG
2023-05-04T09:36:36.480+0200 [DEBUG] jetstream_kv_bucket.CFG: applying the planned Create change
2023-05-04T09:36:36.839+0200 [WARN]  unexpected data: registry.terraform.io/nats-io/jetstream:stderr="nats: Permissions Violation for Publish to "$JS.API.INFO" on connection [4611]"
2023-05-04T09:36:41.801+0200 [ERROR] vertex "jetstream_kv_bucket.CFG" error: context deadline exceeded
╷
│ Error: context deadline exceeded
│ 
│   with jetstream_kv_bucket.CFG,
│   on main.tf line 6, in resource "jetstream_kv_bucket" "CFG":
│    6: resource "jetstream_kv_bucket" "CFG" {
│ 
╵
2023-05-04T09:36:41.809+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2023-05-04T09:36:41.811+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/registry.terraform.io/nats-io/jetstream/0.0.35/darwin_arm64/terraform-provider-jetstream_v0.0.35 pid=8424
2023-05-04T09:36:41.811+0200 [DEBUG] provider: plugin exited
```