### PR TITLE
add jetstream_kv_entry resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ resource "jetstream_kv_bucket" "test" {
  * `max_bucket_size` - (optional) The maximum size of all data in the bucket
  * `replicas` - (optional) How many replicas to keep on a JetStream cluster
 
+## jetstream_kv_entry
+
+Creates a JetStream based KV bucket entry
+
+### Example
+
+```terraform
+resource "jetstream_kv_entry" "test_entry" {
+  bucket = "TEST"
+  key = "foo"
+  value = "bar"
+}
+```
+
+### Attribute Reference
+
+ * `bucket` - (required) The name of the KV bucket
+ * `key` - (required) The entry key
+ * `value` - (required) The entry value
+
 # Import existing JetStream resources 
 
 See [docs/guides/import.md](docs/guides/import.md) 

--- a/docs/resources/jetstream_kv_entry.md
+++ b/docs/resources/jetstream_kv_entry.md
@@ -1,0 +1,31 @@
+## jetstream_kv_entry Resource
+
+The `jetstream_kv_entry` Resource manages entries in JetStream Based Key-Value buckets and supports editing entries in place.
+
+### Example
+
+Using a string value:
+
+```hcl
+resource "jetstream_kv_entry" "myservice_cfg" {
+  bucket = "CFG"
+  key = "config.myservice.timeout"
+  value = "10"
+}
+```
+
+Using json:
+
+```hcl
+resource "jetstream_kv_entry" "myservice_cfg" {
+  bucket = "CFG"
+  key = "config.myservice"
+  value = jsonencode({timeout: 10, retries: 3})
+}
+```
+
+### Attribute Reference
+
+ * `bucket` - (required) The name of the KV bucket
+ * `key` - (required) The entry key
+ * `value` - (required) The entry value

--- a/jetstream/provider.go
+++ b/jetstream/provider.go
@@ -10,6 +10,7 @@ import (
 var streamIdRegex = regexp.MustCompile("^JETSTREAM_STREAM_(.+)$")
 var consumerIdRegex = regexp.MustCompile("^JETSTREAM_STREAM_(.+?)_CONSUMER_(.+)$")
 var kvIdRegex = regexp.MustCompile("^JETSTREAM_KV_(.+)$")
+var kvEntryIdRegex = regexp.MustCompile("^JETSTREAM_KV_(.+?)_ENTRY_(.+)$")
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
@@ -93,6 +94,7 @@ func Provider() terraform.ResourceProvider {
 			"jetstream_stream":    resourceStream(),
 			"jetstream_consumer":  resourceConsumer(),
 			"jetstream_kv_bucket": resourceKVBucket(),
+			"jetstream_kv_entry":  resourceKVEntry(),
 		},
 
 		ConfigureFunc: connectMgr,

--- a/jetstream/resource_kv_entry.go
+++ b/jetstream/resource_kv_entry.go
@@ -1,0 +1,163 @@
+package jetstream
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats.go"
+)
+
+func resourceKVEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKVEntryCreate,
+		Read:   resourceKVEntryRead,
+		Update: resourceKVEntryUpdate,
+		Delete: resourceKVEntryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:        schema.TypeString,
+				Description: "The name of the bucket",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"key": {
+				Type:        schema.TypeString,
+				Description: "The key of the entry",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Description: "The value of the entry",
+				Required:    true,
+				ForceNew:    false,
+			},
+			"revision": {
+				Type:        schema.TypeInt,
+				Description: "The revision of the entry",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceKVEntryCreate(d *schema.ResourceData, m any) error {
+	nc, _, err := m.(func() (*nats.Conn, *jsm.Manager, error))()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	bucket := d.Get("bucket").(string)
+	key := d.Get("key").(string)
+	value := d.Get("value").(string)
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return err
+	}
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		return err
+	}
+	_, err = kv.Put(key, []byte(value))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("JETSTREAM_KV_%s_ENTRY_%s", bucket, key))
+
+	return resourceKVEntryRead(d, m)
+}
+
+func resourceKVEntryRead(d *schema.ResourceData, m any) error {
+	bucket, key, err := parseStreamKVEntryID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	nc, _, err := m.(func() (*nats.Conn, *jsm.Manager, error))()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return err
+	}
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		return err
+	}
+	entry, err := kv.Get(key)
+	if err != nil {
+		return err
+	}
+
+	d.Set("bucket", entry.Bucket())
+	d.Set("key", entry.Key())
+	d.Set("value", string(entry.Value()))
+	d.Set("revision", entry.Revision())
+
+	return nil
+}
+
+func resourceKVEntryUpdate(d *schema.ResourceData, m any) error {
+	bucket := d.Get("bucket").(string)
+
+	nc, _, err := m.(func() (*nats.Conn, *jsm.Manager, error))()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return err
+	}
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		return err
+	}
+
+	key := d.Get("key").(string)
+	value := d.Get("value").(string)
+
+	_, err = kv.Put(key, []byte(value))
+	if err != nil {
+		return err
+	}
+
+	return resourceKVEntryRead(d, m)
+}
+
+func resourceKVEntryDelete(d *schema.ResourceData, m any) error {
+	bucket := d.Get("bucket").(string)
+
+	nc, _, err := m.(func() (*nats.Conn, *jsm.Manager, error))()
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return err
+	}
+	kv, err := js.KeyValue(bucket)
+	if err != nil {
+		return err
+	}
+	err = kv.Delete(d.Get("key").(string))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/jetstream/resource_kv_entry_test.go
+++ b/jetstream/resource_kv_entry_test.go
@@ -1,0 +1,111 @@
+package jetstream
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats.go"
+)
+
+const testKVEntry_basic = `
+provider "jetstream" {
+  servers = "%s"
+}
+
+resource "jetstream_kv_bucket" "test" {
+  name = "TEST"
+  ttl = 60
+  history = 10
+  max_value_size = 1024
+  max_bucket_size = 10240
+}
+
+resource "jetstream_kv_entry" "test_entry" {
+  bucket = jetstream_kv_bucket.test.name
+  key = "foo"
+  value = "bar"
+}
+`
+
+func TestResourceKVEntry(t *testing.T) {
+	srv := createJSServer(t)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	defer nc.Close()
+
+	mgr, err := jsm.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	updateBasicConfig := strings.ReplaceAll(testKVEntry_basic, "bar", "baz")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testJsProviders,
+		CheckDestroy: testEntryDoesNotExist(t, js, "TEST", "foo"),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testKVEntry_basic, nc.ConnectedUrl()),
+				Check: resource.ComposeTestCheckFunc(
+					testBucketExist(t, mgr, "TEST"),
+					testEntryExist(t, js, "TEST", "foo"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "bucket", "TEST"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "key", "foo"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "value", "bar"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "revision", "1"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(updateBasicConfig, nc.ConnectedUrl()),
+				Check: resource.ComposeTestCheckFunc(
+					testBucketExist(t, mgr, "TEST"),
+					testEntryExist(t, js, "TEST", "foo"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "bucket", "TEST"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "key", "foo"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "value", "baz"),
+					resource.TestCheckResourceAttr("jetstream_kv_entry.test_entry", "revision", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testEntryDoesNotExist(t *testing.T, js nats.JetStreamContext, bucket string, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err := testEntryExist(t, js, bucket, key)
+		if err == nil {
+			return fmt.Errorf("expected entry %q in bucket %q to not exist", key, bucket)
+		}
+
+		return nil
+	}
+}
+
+func testEntryExist(t *testing.T, js nats.JetStreamContext, bucket string, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		kv, err := js.KeyValue(bucket)
+		if err != nil {
+			return err
+		}
+
+		_, err = kv.Get(key)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/jetstream/util.go
+++ b/jetstream/util.go
@@ -20,6 +20,15 @@ var (
 	connectMu sync.Mutex
 )
 
+func parseStreamKVEntryID(id string) (bucket string, key string, err error) {
+	if !kvEntryIdRegex.MatchString(id) {
+		return "", "", fmt.Errorf("invalid kv entry id %q", id)
+	}
+
+	matches := kvEntryIdRegex.FindStringSubmatch(id)
+	return matches[1], matches[2], nil
+}
+
 func parseStreamKVID(id string) (string, error) {
 	if !kvIdRegex.MatchString(id) {
 		return "", fmt.Errorf("invalid kv bucket id %q", id)


### PR DESCRIPTION
We want to use JetStream KV to configure our services. Being able to manage the config in terraform by declaring a `jetstream_kv_entry` would enable us to do this and replace SSM.