### PR TITLE
handle cases where bucket or entry doesn't exist

### DIFF
--- a/jetstream/resource_kv_bucket.go
+++ b/jetstream/resource_kv_bucket.go
@@ -172,6 +172,10 @@ func resourceKVBucketRead(d *schema.ResourceData, m any) error {
 	}
 	bucket, err := js.KeyValue(name)
 	if err != nil {
+		if err == nats.ErrBucketNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	status, err := bucket.Status()

--- a/jetstream/resource_kv_entry.go
+++ b/jetstream/resource_kv_entry.go
@@ -93,10 +93,18 @@ func resourceKVEntryRead(d *schema.ResourceData, m any) error {
 	}
 	kv, err := js.KeyValue(bucket)
 	if err != nil {
+		if err == nats.ErrBucketNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	entry, err := kv.Get(key)
 	if err != nil {
+		if err == nats.ErrKeyNotFound {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When creating a bucket or entry that was previously in terraform state but has been deleted in nats, the provider would error instead of trying to create either the bucket or entry again as expected in terraform. This was due to incorrectly handling the non-exist case in the respective read functions. This behaviour now matches that of streams/consumers.