### PR TITLE
[FEAT]: adds FilterSubjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ resource "jetstream_consumer" "ORDERS_NEW" {
  * `delivery_group` - (optional) When set Push consumers will only deliver messages to subscriptions with this group set
  * `durable_name` - The durable name of the Consumer
  * `filter_subject` - (optional) Only receive a subset of messages from the Stream based on the subject they entered the Stream on
- * `filter_subjects` - (optional) Only receive a subset tof messages from the Stream based on subjects they entered the Stream on. Only works with v2.10 or better.
+ * `filter_subjects` - (optional) Only receive a subset tof messages from the Stream based on subjects they entered the Stream on. This is exclusive to `filter_subject`. Only works with v2.10 or better.
  * `max_delivery` - (optional) Maximum deliveries to attempt for each message
  * `replay_policy` - (optional) The rate at which messages will be replayed from the stream
  * `sample_freq` - (optional) The percentage of acknowledgements that will be sampled for observability purposes

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ resource "jetstream_consumer" "ORDERS_NEW" {
  * `delivery_group` - (optional) When set Push consumers will only deliver messages to subscriptions with this group set
  * `durable_name` - The durable name of the Consumer
  * `filter_subject` - (optional) Only receive a subset of messages from the Stream based on the subject they entered the Stream on
+ * `filter_subjects` - (optional) Only receive a subset tof messages from the Stream based on subjects they entered the Stream on. Only works with v2.10 or better.
  * `max_delivery` - (optional) Maximum deliveries to attempt for each message
  * `replay_policy` - (optional) The rate at which messages will be replayed from the stream
  * `sample_freq` - (optional) The percentage of acknowledgements that will be sampled for observability purposes

--- a/docs/resources/jetstream_consumer.md
+++ b/docs/resources/jetstream_consumer.md
@@ -33,6 +33,7 @@ resource "jetstream_consumer" "ORDERS_NEW" {
  * `delivery_group` - (optional) When set Push consumers will only deliver messages to subscriptions with this group set
  * `durable_name` - The durable name of the Consumer
  * `filter_subject` - (optional) Only receive a subset of messages from the Stream based on the subject they entered the Stream on
+ * `filter_subjects` - (optional) Only receive a subset tof messages from the Stream based on subjects they entered the Stream on. This is exclusive to `filter_subject`. Only works with v2.10 or better.
  * `max_delivery` - (optional) Maximum deliveries to attempt for each message
  * `replay_policy` - (optional) The rate at which messages will be replayed from the stream
  * `sample_freq` - (optional) The percentage of acknowledgements that will be sampled for observability purposes

--- a/jetstream/resource_jetstream_consumer.go
+++ b/jetstream/resource_jetstream_consumer.go
@@ -131,11 +131,11 @@ func resourceConsumer() *schema.Resource {
 				ForceNew:    false,
 			},
 			"filter_subject": {
-				Type:        schema.TypeString,
-				Description: "Only receive a subset of messages from the Stream based on the subject they entered the Stream on",
-				Default:     "",
-				Optional:    true,
-				ForceNew:    false,
+				Type:          schema.TypeString,
+				Description:   "Only receive a subset of messages from the Stream based on the subject they entered the Stream on",
+				Default:       "",
+				Optional:      true,
+				ForceNew:      false,
 				ConflictsWith: []string{"filter_subjects"},
 			},
 			"filter_subjects": {

--- a/jetstream/resource_jetstream_consumer_test.go
+++ b/jetstream/resource_jetstream_consumer_test.go
@@ -136,7 +136,6 @@ func TestResourceConsumer(t *testing.T) {
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C3", "filter_subject", "TEST.a"),
 				),
 			},
-
 		},
 	})
 }

--- a/jetstream/resource_jetstream_consumer_test.go
+++ b/jetstream/resource_jetstream_consumer_test.go
@@ -49,6 +49,7 @@ resource "jetstream_consumer" "TEST_C2" {
   durable_name    = "C2"
   stream_sequence = 10
   max_ack_pending = 20
+  filter_subjects = ["TEST.a", "TEST.b"]
 }
 `
 
@@ -101,6 +102,7 @@ func TestResourceConsumer(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testStreamExist(t, mgr, "TEST"),
 					testConsumerExist(t, mgr, "TEST", "C2"),
+					testConsumerHasFilterSubjects(t, mgr, "TEST", "C2", []string{"TEST.a", "TEST.b"}),
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C2", "stream_sequence", "10"),
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C2", "max_ack_pending", "20"),
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C2", "inactive_threshold", "0"),

--- a/jetstream/util_test.go
+++ b/jetstream/util_test.go
@@ -41,6 +41,23 @@ func testConsumerHasMetadata(t *testing.T, mgr *jsm.Manager, stream string, cons
 	}
 }
 
+func testConsumerHasFilterSubjects(t *testing.T, mgr *jsm.Manager, stream string, consumer string, subjects []string) resource.TestCheckFunc {
+	return func(s* terraform.State) error {
+		cons, err := mgr.LoadConsumer(stream, consumer)
+		if err != nil {
+			return err
+		}
+		if len(cons.FilterSubjects()) == 0 && len(subjects) == 0 {
+			return nil
+		}
+		if cmp.Equal(cons.FilterSubjects(), subjects) {
+			return nil
+		}
+
+		return fmt.Errorf("expected %q got %q", subjects, cons.FilterSubjects())
+	}
+}
+
 func testStreamHasSubjects(t *testing.T, mgr *jsm.Manager, stream string, subjects []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		str, err := mgr.LoadStream(stream)

--- a/jetstream/util_test.go
+++ b/jetstream/util_test.go
@@ -42,7 +42,7 @@ func testConsumerHasMetadata(t *testing.T, mgr *jsm.Manager, stream string, cons
 }
 
 func testConsumerHasFilterSubjects(t *testing.T, mgr *jsm.Manager, stream string, consumer string, subjects []string) resource.TestCheckFunc {
-	return func(s* terraform.State) error {
+	return func(s *terraform.State) error {
 		cons, err := mgr.LoadConsumer(stream, consumer)
 		if err != nil {
 			return err


### PR DESCRIPTION
NATS v2.10+ consumer adds new parameter `FilterSubjects` as documented [here](https://github.com/nats-io/nats.go/blob/main/jetstream/consumer_config.go#L71). This PR adds `filter_subjects` in jetstream consumer. 