### PR TITLE
Fix ability to set subject_transform on streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ resource "jetstream_stream" "ORDERS" {
   storage  = "file"
   max_age  = 60 * 60 * 24 * 365
 }
+
+resource "jetstream_stream" "TRANSFORM" {
+  name     = "TRANSFORM"
+  subjects = ["TRANSFORM.*"]
+  storage  = "file"
+  subject_transform {
+    source      = "TRANSFORM.>"
+    destination = "NEWSUBJECT.>"
+  }
+}
 ```
 
 ### Attribute Reference
@@ -151,6 +161,7 @@ resource "jetstream_stream" "ORDERS" {
  * `deny_purge` - (optional) Restricts the ability to purge messages from a stream via the API. Cannot be change once set to true (bool)
  * `allow_rollup_hdrs` - (optional) Allows the use of the Nats-Rollup header to replace all contents of a stream, or subject in a stream, with a single new message (bool)
  * `allow_direct` - (optional) Allow higher performance, direct access to get individual messages via the $JS.DS.GET API (bool)
+ * `subject_transform` - (optional) A map of source and destination subjects to transform.
 
 ## jetstream_consumer
 

--- a/jetstream/resource_jetstream_stream.go
+++ b/jetstream/resource_jetstream_stream.go
@@ -367,6 +367,7 @@ func resourceStreamRead(d *schema.ResourceData, m any) error {
 	d.Set("allow_direct", str.DirectAllowed())
 	d.Set("discard_new_per_subject", str.DiscardNewPerSubject())
 	d.Set("compression", str.Compression())
+	d.Set("subject_transform", str.Configuration().SubjectTransform)
 
 	if str.MaxAge() == -1 || str.MaxAge() == 0 {
 		d.Set("max_age", "-1")

--- a/jetstream/resource_jetstream_stream_test.go
+++ b/jetstream/resource_jetstream_stream_test.go
@@ -281,6 +281,7 @@ func TestResourceStream(t *testing.T) {
 					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.0.source", "TEST.>"),
 					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.0.destination", "1.>"),
 					testStreamHasSubjects(t, mgr, "TEST", []string{"TEST.*"}),
+					testStreamIsTransformed(t, mgr, "TEST", api.SubjectTransformConfig{Source: "TEST.>", Destination: "1.>"}),
 				),
 			},
 		},

--- a/jetstream/resource_jetstream_stream_test.go
+++ b/jetstream/resource_jetstream_stream_test.go
@@ -278,8 +278,8 @@ func TestResourceStream(t *testing.T) {
 				Config: fmt.Sprintf(testStreamSubjectTransform, nc.ConnectedUrl()),
 				Check: resource.ComposeTestCheckFunc(
 					testStreamExist(t, mgr, "TEST"),
-					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.source", "TEST.>"),
-					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.destination", "1.>"),
+					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.0.source", "TEST.>"),
+					resource.TestCheckResourceAttr("jetstream_stream.test", "subject_transform.0.destination", "1.>"),
 					testStreamHasSubjects(t, mgr, "TEST", []string{"TEST.*"}),
 				),
 			},

--- a/jetstream/resource_jetstream_stream_test.go
+++ b/jetstream/resource_jetstream_stream_test.go
@@ -167,10 +167,10 @@ provider "jetstream" {
 resource "jetstream_stream" "test" {
 	name = "TEST"
 	subjects = ["TEST.*"]
-    subject_transform {
-      source = "TEST.>"
-      destination = "1.>"
-    }
+	subject_transform {
+		source = "TEST.>"
+		destination = "1.>"
+	}
 }
 `
 

--- a/jetstream/util.go
+++ b/jetstream/util.go
@@ -166,13 +166,11 @@ func streamConfigFromResourceData(d *schema.ResourceData) (cfg api.StreamConfig,
 	var subjectTransforms *api.SubjectTransformConfig
 	transforms := d.Get("subject_transform").([]any)
 
-	if len(transforms) > 0 {
-		for _, transform := range transforms {
-			st := transform.(map[string]any)
-			subjectTransforms = &api.SubjectTransformConfig{
-				Source:      st["source"].(string),
-				Destination: st["destination"].(string),
-			}
+	for _, transform := range transforms {
+		st := transform.(map[string]any)
+		subjectTransforms = &api.SubjectTransformConfig{
+			Source:      st["source"].(string),
+			Destination: st["destination"].(string),
 		}
 	}
 

--- a/jetstream/util.go
+++ b/jetstream/util.go
@@ -163,6 +163,19 @@ func streamConfigFromResourceData(d *schema.ResourceData) (cfg api.StreamConfig,
 		subjects[i] = sub.(string)
 	}
 
+	var subjectTransforms *api.SubjectTransformConfig
+	transforms := d.Get("subject_transform").([]any)
+
+	if len(transforms) > 0 {
+		for _, transform := range transforms {
+			st := transform.(map[string]any)
+			subjectTransforms = &api.SubjectTransformConfig{
+				Source:      st["source"].(string),
+				Destination: st["destination"].(string),
+			}
+		}
+	}
+
 	var placement *api.Placement
 	c, ok := d.GetOk("placement_cluster")
 	if ok {
@@ -179,25 +192,26 @@ func streamConfigFromResourceData(d *schema.ResourceData) (cfg api.StreamConfig,
 	}
 
 	stream := api.StreamConfig{
-		Name:          d.Get("name").(string),
-		Subjects:      subjects,
-		Retention:     retention,
-		Discard:       discard,
-		DiscardNewPer: d.Get("discard_new_per_subject").(bool),
-		MaxConsumers:  d.Get("max_consumers").(int),
-		MaxMsgs:       int64(d.Get("max_msgs").(int)),
-		MaxBytes:      int64(d.Get("max_bytes").(int)),
-		MaxAge:        time.Second * time.Duration(d.Get("max_age").(int)),
-		Duplicates:    time.Second * time.Duration(d.Get("duplicate_window").(int)),
-		MaxMsgSize:    int32(d.Get("max_msg_size").(int)),
-		Storage:       storage,
-		Replicas:      d.Get("replicas").(int),
-		NoAck:         !d.Get("ack").(bool),
-		AllowDirect:   d.Get("allow_direct").(bool),
-		DenyDelete:    d.Get("deny_delete").(bool),
-		DenyPurge:     d.Get("deny_purge").(bool),
-		RollupAllowed: d.Get("allow_rollup_hdrs").(bool),
-		Placement:     placement,
+		Name:             d.Get("name").(string),
+		Subjects:         subjects,
+		Retention:        retention,
+		Discard:          discard,
+		DiscardNewPer:    d.Get("discard_new_per_subject").(bool),
+		MaxConsumers:     d.Get("max_consumers").(int),
+		MaxMsgs:          int64(d.Get("max_msgs").(int)),
+		MaxBytes:         int64(d.Get("max_bytes").(int)),
+		MaxAge:           time.Second * time.Duration(d.Get("max_age").(int)),
+		Duplicates:       time.Second * time.Duration(d.Get("duplicate_window").(int)),
+		MaxMsgSize:       int32(d.Get("max_msg_size").(int)),
+		Storage:          storage,
+		Replicas:         d.Get("replicas").(int),
+		NoAck:            !d.Get("ack").(bool),
+		AllowDirect:      d.Get("allow_direct").(bool),
+		DenyDelete:       d.Get("deny_delete").(bool),
+		DenyPurge:        d.Get("deny_purge").(bool),
+		RollupAllowed:    d.Get("allow_rollup_hdrs").(bool),
+		Placement:        placement,
+		SubjectTransform: subjectTransforms,
 	}
 
 	repubSrc := d.Get("republish_source").(string)

--- a/jetstream/util.go
+++ b/jetstream/util.go
@@ -166,11 +166,13 @@ func streamConfigFromResourceData(d *schema.ResourceData) (cfg api.StreamConfig,
 	var subjectTransforms *api.SubjectTransformConfig
 	transforms := d.Get("subject_transform").([]any)
 
-	for _, transform := range transforms {
-		st := transform.(map[string]any)
-		subjectTransforms = &api.SubjectTransformConfig{
-			Source:      st["source"].(string),
-			Destination: st["destination"].(string),
+	if len(transforms) == 1 {
+		for _, transform := range transforms {
+			st := transform.(map[string]any)
+			subjectTransforms = &api.SubjectTransformConfig{
+				Source:      st["source"].(string),
+				Destination: st["destination"].(string),
+			}
 		}
 	}
 

--- a/jetstream/util_test.go
+++ b/jetstream/util_test.go
@@ -273,3 +273,20 @@ func testConsumerDoesNotExist(t *testing.T, mgr *jsm.Manager, stream string, con
 		return nil
 	}
 }
+
+//func testStreamIsTransformed
+
+func testStreamIsTransformed(t *testing.T, mgr *jsm.Manager, stream string, transform api.SubjectTransformConfig) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		str, err := mgr.LoadStream(stream)
+		if err != nil {
+			return err
+		}
+
+		if *str.Configuration().SubjectTransform != transform {
+			return fmt.Errorf("subject transform %v does not match %v", *str.Configuration().SubjectTransform, transform)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
Currently the subject_transform does not get set on streams or read from NATS. It only exists in the schema and is saved to the state, but no changes apply.