### PR TITLE
Allow setting max_waiting for pull consumers

### DIFF
--- a/jetstream/resource_jetstream_consumer.go
+++ b/jetstream/resource_jetstream_consumer.go
@@ -288,8 +288,9 @@ func consumerConfigFromResourceData(d *schema.ResourceData) (cfg api.ConsumerCon
 	}
 
 	if cfg.DeliverSubject != "" {
-		cfg.MaxWaiting = d.Get("max_waiting").(int)
 		cfg.DeliverGroup = d.Get("delivery_group").(string)
+	} else {
+		cfg.MaxWaiting = d.Get("max_waiting").(int)
 	}
 
 	for _, d := range d.Get("backoff").([]any) {

--- a/jetstream/resource_jetstream_consumer_test.go
+++ b/jetstream/resource_jetstream_consumer_test.go
@@ -28,6 +28,7 @@ resource "jetstream_consumer" "TEST_C1" {
   inactive_threshold = 60
   max_delivery       = 10
   backoff            = [30, 60]
+  max_waiting        = 256
   metadata           = {
     foo = "bar"
   }
@@ -114,6 +115,7 @@ func TestResourceConsumer(t *testing.T) {
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C1", "stream_sequence", "0"),
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C1", "description", "new description"),
 					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C1", "inactive_threshold", "60"),
+					resource.TestCheckResourceAttr("jetstream_consumer.TEST_C1", "max_waiting", "256"),
 				),
 			},
 			{


### PR DESCRIPTION
* it's a pull consumer if `delivery_subject` is empty

https://github.com/nats-io/terraform-provider-jetstream/issues/114