### PR TITLE
(#119) Fix sampleFrequency parsing in update function

### DIFF
--- a/jetstream/resource_jetstream_consumer.go
+++ b/jetstream/resource_jetstream_consumer.go
@@ -415,10 +415,13 @@ func resourceConsumerUpdate(d *schema.ResourceData, m any) error {
 		return err
 	}
 
-	s := strings.TrimSuffix(cons.SampleFrequency(), "%")
-	freq, err := strconv.Atoi(s)
-	if err != nil {
-		return fmt.Errorf("failed to parse consumer sampling configuration: %v", err)
+	freq := 0
+	if len(cons.SampleFrequency()) > 0 {
+		s := strings.TrimSuffix(cons.SampleFrequency(), "%")
+		freq, err = strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("failed to parse consumer sampling configuration: %v", err)
+		}
 	}
 
 	opts := []jsm.ConsumerOption{


### PR DESCRIPTION
When a consumer config is created with sampleFrequency as 0%, the consumer will store this as an empty string. We will now check the value of sampleFrequency before trying to parse the string.