### PR TITLE
(#114) Fix changing `max_waiting` value when `delivery_subject` is set

### DIFF
--- a/jetstream/resource_jetstream_consumer_test.go
+++ b/jetstream/resource_jetstream_consumer_test.go
@@ -51,6 +51,7 @@ resource "jetstream_consumer" "TEST_C2" {
   stream_sequence = 10
   max_ack_pending = 20
   filter_subjects = ["TEST.a", "TEST.b"]
+  max_waiting      = 10
 }
 `
 
@@ -70,6 +71,7 @@ resource "jetstream_consumer" "TEST_C3" {
   stream_sequence = 10
   max_ack_pending = 20
   filter_subject = "TEST.a"
+  delivery_subject = "ORDERS.a"
 }
 `
 


### PR DESCRIPTION
Here we update the `max_waiting` consumer resource field to be computed. This allows us to set its value to 0 when `delivery_subject` is set and not have it flip to the default on every apply.

`max_waiting` now also conficts with the `delivery_subject` field, since these two imply the use of push vs pull consumers and don't make sense when specified together.