### PR TITLE
Add possible retention policy values to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ resource "jetstream_stream" "TRANSFORM" {
  * `max_msgs_per_subject` (optional) The maximum amount of messages that can be kept in the stream on a per-subject basis (number)
  * `name` - The name of the stream (string)
  * `replicas` - (optional) How many replicas of the data to keep in a clustered environment (number)
- * `retention` - (optional) The retention policy to apply over and above max_msgs, max_bytes and max_age (string)
+ * `retention` - (optional) The retention policy to apply over and above max_msgs, max_bytes and max_age (string). Options are `limits`, `interest` and `workqueue`. Defaults to `limits`.
  * `storage` - (optional) The storage engine to use to back the stream (string)
  * `subjects` - The list of subjects that will be consumed by the Stream (["list", "string"])
  * `duplicate_window` - (optional) The time window size for duplicate tracking, duration specified in seconds (number)

--- a/docs/resources/jetstream_stream.md
+++ b/docs/resources/jetstream_stream.md
@@ -54,7 +54,7 @@ Above the `ORDERS_ARCHIVE` stream is a mirror of `ORDERS`, valid options for spe
  * `max_msgs_per_subject` (optional) The maximum amount of messages that can be kept in the stream on a per-subject basis (number)
  * `name` - The name of the stream (string)
  * `replicas` - (optional) How many replicas of the data to keep in a clustered environment (number)
- * `retention` - (optional) The retention policy to apply over and above max_msgs, max_bytes and max_age (string)
+ * `retention` - (optional) The retention policy to apply over and above max_msgs, max_bytes and max_age (string). Options are `limits`, `interest` and `workqueue`. Defaults to `limits`.
  * `storage` - (optional) The storage engine to use to back the stream (string)
  * `subjects` - The list of subjects that will be consumed by the Stream (["list", "string"])
  * `duplicate_window` - (optional) The time window size for duplicate tracking, duration specified in seconds (number)


### PR DESCRIPTION
While the possible retention policies are clear from the [NATS docs](https://docs.nats.io/nats-concepts/jetstream/streams#retentionpolicy), the string that can be used in the Terraform config is slightly different and not obvious (e.g. it's not obvious what is correct: `WorkQueuePolicy`, `WorkQueue`, `workqueue`, `work_queue`, `work-queue`, or something else). One has to check [the source code](https://github.com/nats-io/terraform-provider-jetstream/blob/main/jetstream/util.go#L97) to find out the allowed values.

Therefore, this PR aims to make it easier for people to use the Terraform provider by providing explicitly the allowed values for the retention policy in the README.