### PR TITLE
Fix consumer imports that would flip flop

### DIFF
--- a/ABTaskFile
+++ b/ABTaskFile
@@ -97,10 +97,10 @@ commands:
           aliases: [bin]
           description: Build a basic test binary
           type: exec
-          dir: "{{ TaskDir }}/nats"
+          dir: "{{ TaskDir }}"
           banner: |
               >>>
-              >>> Building 'nats' locally {{ if .Flags.target }}for target '{{ .Flags.target }}'{{ end }}
+              >>> Building 'terraform-provider-jetstream' locally {{ if .Flags.target }}for target '{{ .Flags.target }}'{{ end }}
               >>>
           flags:
             - name: target
@@ -113,9 +113,9 @@ commands:
                 export GOARCH=amd64
             {{ end }}
 
-            go build -o nats
+            go build -o terraform-provider-jetstream
 
-            ls -l nats
+            ls -l terraform-provider-jetstream
 
         - name: snapshot
           description: Goreleaser snapshot

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/zclconf/go-cty v1.16.2 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
@@ -71,7 +71,7 @@ require (
 	golang.org/x/tools v0.31.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
-	google.golang.org/grpc v1.71.0 // indirect
+	google.golang.org/grpc v1.71.1 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nats-io/jsm.go v0.2.0 h1:YaMEowDPg5wxyM/kibQcPyv8qOpPC+PUBhPwQz6uoI8=
 github.com/nats-io/jsm.go v0.2.0/go.mod h1:sKOIvr0L5lQXGsq1GuUa9ycuphKmVCCCsieIhKqCPmU=
+github.com/nats-io/jsm.go v0.2.1-0.20250331104711-86264b22d2b1 h1:w0Aoj9RL6GRmHtchZn5Twxa8r0K13wVpquIx9zK4Pg0=
+github.com/nats-io/jsm.go v0.2.1-0.20250331104711-86264b22d2b1/go.mod h1:sKOIvr0L5lQXGsq1GuUa9ycuphKmVCCCsieIhKqCPmU=
 github.com/nats-io/jwt/v2 v2.7.3 h1:6bNPK+FXgBeAqdj4cYQ0F8ViHRbi7woQLq4W29nUAzE=
 github.com/nats-io/jwt/v2 v2.7.3/go.mod h1:GvkcbHhKquj3pkioy5put1wvPxs78UlZ7D/pY+BgZk4=
 github.com/nats-io/nats-server/v2 v2.11.0 h1:fdwAT1d6DZW/4LUz5rkvQUe5leGEwjjOQYntzVRKvjE=
@@ -206,8 +208,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -249,8 +251,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 h1:e0AIkUUhxyBKh6ssZNrAMeqhA7RKUj42346d1y02i2g=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
-google.golang.org/grpc v1.71.0 h1:kF77BGdPTQ4/JZWMlb9VpJ5pa25aqvVqogsxNHHdeBg=
-google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
+google.golang.org/grpc v1.71.1 h1:ffsFWr7ygTUscGPI0KKK6TLrGz0476KUvvsbqWK0rPI=
+google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=

--- a/jetstream/resource_jetstream_consumer.go
+++ b/jetstream/resource_jetstream_consumer.go
@@ -502,6 +502,7 @@ func resourceConsumerRead(d *schema.ResourceData, m any) error {
 		return err
 	}
 
+	d.Set("stream_id", fmt.Sprintf("JETSTREAM_STREAM_%s", stream))
 	d.Set("description", cons.Description())
 	d.Set("metadata", jsm.FilterServerMetadata(cons.Metadata()))
 	d.Set("durable_name", cons.DurableName())
@@ -524,10 +525,7 @@ func resourceConsumerRead(d *schema.ResourceData, m any) error {
 	d.Set("max_bytes", cons.MaxRequestMaxBytes())
 	d.Set("replicas", cons.Replicas())
 	d.Set("memory", cons.MemoryStorage())
-
-	if cons.InactiveThreshold() != 0 {
-		d.Set("inactive_threshold", cons.InactiveThreshold().Seconds())
-	}
+	d.Set("inactive_threshold", cons.InactiveThreshold().Seconds())
 
 	switch cons.DeliverPolicy() {
 	case api.DeliverAll:
@@ -551,6 +549,8 @@ func resourceConsumerRead(d *schema.ResourceData, m any) error {
 			return fmt.Errorf("failed to parse consumer sampling configuration: %v", err)
 		}
 		d.Set("sample_freq", freq)
+	} else {
+		d.Set("sample_freq", 0)
 	}
 
 	d.Set("start_time", "")


### PR DESCRIPTION
This ensures stream_id, inactive_threshold and sample_freq are always set avoiding some flip flops during import