### PR TITLE
Fixes consumer resource page heading

### DIFF
--- a/docs/resources/jetstream_consumer.md
+++ b/docs/resources/jetstream_consumer.md
@@ -1,4 +1,4 @@
-# jetstream_stream Resource
+# jetstream_consumer Resource
 
 The `jetstream_consumer` Resource creates, updates or deletes JetStream Consumers on any Terraform managed Stream.
 


### PR DESCRIPTION
As described in https://github.com/nats-io/terraform-provider-jetstream/issues/151, the JetStream Consumer resource docs say `jetstream_stream` at the top, instead of `jetstream_consumer`. This quick change fixes that.