### PR TITLE
feat: add resource for object store buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a Terraform provider capable of managing the following JetStream assets:
  * Consumers
  * Key-Value Buckets
  * Key-Value Entries
+ * Object Store Buckets
 
 > [!WARNING]
 >
@@ -296,6 +297,32 @@ resource "jetstream_kv_entry" "test_entry" {
  * `bucket` - (required) The name of the KV bucket
  * `key` - (required) The entry key
  * `value` - (required) The entry value
+
+## jetstream_obj_bucket
+
+Creates a JetStream based Object Store bucket
+
+### Example
+
+```hcl
+resource "jetstream_obj_bucket" "test" {
+  name        = "TEST"
+  description = "Store payloads of arbitrary size"
+  compression = true
+}
+```
+
+### Attribute Reference
+
+ * `name` - (required) The unique name of the Object Store bucket, must match `\A[a-zA-Z0-9_-]+\z`
+ * `description` - (optional) Contains additional information about this bucket
+ * `storage` - (optional) Storage backend to use, defaults to `file`, can be `file` or `memory`
+ * `ttl` - (optional) How many seconds to keep objects for, keeps forever when not set
+ * `placement_cluster` - (optional) Place the bucket in a specific cluster, influenced by placement_tags
+ * `placement_tags` - (optional) Place the bucket only on servers with these tags
+ * `max_bucket_size` - (optional) The maximum size of all data in the bucket
+ * `replicas` - (optional) How many replicas to keep on a JetStream cluster
+ * `compression` - (optional) Enables compression for objects stored in the bucket
 
 # Import existing JetStream resources 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,4 @@ resource "jetstream_consumer" "ORDERS_NEW" {
  * `jetstream_stream` - Manage a Stream that persistently stores messages
  * `jetstream_consumer` - Creates a Consumer that defines how Stream messages can be consumed by clients
  * `jetstream_kv_bucket` - Creates a Key-Value store
+ * `jetstream_obj_bucket` - Creates an Object Store bucket

--- a/docs/resources/jetstream_obj_bucket.md
+++ b/docs/resources/jetstream_obj_bucket.md
@@ -1,0 +1,25 @@
+# jetstream_obj_bucket Resource
+
+The `jetstream_obj_bucket` Resource manages JetStream Based Object Store buckets, supports editing Buckets in place.
+
+## Example Usage
+
+```hcl
+resource "jetstream_obj_bucket" "BLOBS" {
+  name        = "BLOBS"
+  description = "Store payloads of arbitrary size"
+  compression = true
+}
+```
+
+### Attribute Reference
+
+ * `name` - (required) The unique name of the Object Store bucket, must match `\A[a-zA-Z0-9_-]+\z`
+ * `description` - (optional) Contains additional information about this bucket
+ * `storage` - (optional) Storage backend to use, defaults to `file`, can be `file` or `memory`
+ * `ttl` - (optional) How many seconds to keep objects for, keeps forever when not set
+ * `placement_cluster` - (optional) Place the bucket in a specific cluster, influenced by placement_tags
+ * `placement_tags` - (optional) Place the bucket only on servers with these tags
+ * `max_bucket_size` - (optional) The maximum size of all data in the bucket
+ * `replicas` - (optional) How many replicas to keep on a JetStream cluster
+ * `compression` - (optional) Enables compression for objects stored in the bucket

--- a/jetstream/provider.go
+++ b/jetstream/provider.go
@@ -23,6 +23,7 @@ var streamIdRegex = regexp.MustCompile("^JETSTREAM_STREAM_(.+)$")
 var consumerIdRegex = regexp.MustCompile("^JETSTREAM_STREAM_(.+?)_CONSUMER_(.+)$")
 var kvIdRegex = regexp.MustCompile("^JETSTREAM_KV_(.+)$")
 var kvEntryIdRegex = regexp.MustCompile("^JETSTREAM_KV_(.+?)_ENTRY_(.+)$")
+var objIdRegex = regexp.MustCompile("^JETSTREAM_OBJ_(.+)$")
 
 func Provider() *schema.Provider {
 	return &schema.Provider{
@@ -103,10 +104,11 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"jetstream_stream":    resourceStream(),
-			"jetstream_consumer":  resourceConsumer(),
-			"jetstream_kv_bucket": resourceKVBucket(),
-			"jetstream_kv_entry":  resourceKVEntry(),
+			"jetstream_stream":     resourceStream(),
+			"jetstream_consumer":   resourceConsumer(),
+			"jetstream_kv_bucket":  resourceKVBucket(),
+			"jetstream_kv_entry":   resourceKVEntry(),
+			"jetstream_obj_bucket": resourceObjBucket(),
 		},
 
 		ConfigureFunc: connectMgr,

--- a/jetstream/resource_obj_bucket.go
+++ b/jetstream/resource_obj_bucket.go
@@ -276,7 +276,6 @@ func resourceObjBucketUpdate(d *schema.ResourceData, m any) error {
 		MaxBytes:    str.CachedInfo().Config.MaxBytes,
 		Storage:     str.CachedInfo().Config.Storage,
 		Replicas:    str.CachedInfo().Config.Replicas,
-		Placement:   str.CachedInfo().Config.Placement,
 		Compression: status.IsCompressed(),
 		Metadata:    str.CachedInfo().Config.Metadata,
 	}
@@ -287,10 +286,24 @@ func resourceObjBucketUpdate(d *schema.ResourceData, m any) error {
 	description := d.Get("description").(string)
 	compression := d.Get("compression").(bool)
 
+	var placement *jetstream.Placement
+	if cluster, ok := d.GetOk("placement_cluster"); ok {
+		placement = &jetstream.Placement{Cluster: cluster.(string)}
+		if rawTags, ok := d.GetOk("placement_tags"); ok {
+			tagList := rawTags.([]any)
+			tags := make([]string, len(tagList))
+			for i, tag := range tagList {
+				tags[i] = tag.(string)
+			}
+			placement.Tags = tags
+		}
+	}
+
 	cfg.TTL = time.Duration(ttl) * time.Second
 	cfg.MaxBytes = int64(maxB)
 	cfg.Replicas = replicas
 	cfg.Description = description
+	cfg.Placement = placement
 	cfg.Compression = compression
 
 	_, err = js.CreateOrUpdateObjectStore(ctx, cfg)

--- a/jetstream/resource_obj_bucket.go
+++ b/jetstream/resource_obj_bucket.go
@@ -1,0 +1,328 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jetstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func resourceObjBucket() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceObjBucketCreate,
+		Read:   resourceObjBucketRead,
+		Update: resourceObjBucketUpdate,
+		Delete: resourceObjBucketDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the Object Store bucket",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Description: "Contains additional information about this bucket",
+				Optional:    true,
+				ForceNew:    false,
+			},
+			"storage": {
+				Type:             schema.TypeString,
+				Description:      "The storage engine to use to back the bucket",
+				Default:          "file",
+				ForceNew:         true,
+				Optional:         true,
+				ValidateDiagFunc: validateStorageTypeString(),
+			},
+			"ttl": {
+				Type:         schema.TypeInt,
+				Description:  "How many seconds an object will be kept in the bucket",
+				Optional:     true,
+				ForceNew:     false,
+				Default:      0,
+				ValidateFunc: validation.IntAtLeast(0),
+			},
+			"max_bucket_size": {
+				Type:         schema.TypeInt,
+				Description:  "Maximum size of the entire bucket",
+				Default:      -1,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.IntAtLeast(-1),
+			},
+			"placement_cluster": {
+				Type:        schema.TypeString,
+				Description: "Place the bucket in a specific cluster, influenced by placement_tags",
+				Default:     "",
+				Optional:    true,
+			},
+			"placement_tags": {
+				Type:        schema.TypeList,
+				Description: "Place the stream only on servers with these tags",
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"replicas": {
+				Type:         schema.TypeInt,
+				Description:  "Number of cluster replicas to store",
+				Default:      1,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.All(validation.IntAtLeast(1), validation.IntAtMost(5)),
+			},
+			"compression": {
+				Type:        schema.TypeBool,
+				Description: "Enables compression for objects stored in the bucket",
+				Optional:    true,
+				ForceNew:    false,
+				Default:     false,
+			},
+		},
+	}
+}
+
+func resourceObjBucketCreate(d *schema.ResourceData, m any) error {
+	nc, err := getConnection(d, m)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	name := d.Get("name").(string)
+	ttl := d.Get("ttl").(int)
+	maxB := d.Get("max_bucket_size").(int)
+	replicas := d.Get("replicas").(int)
+	description := d.Get("description").(string)
+	compression := d.Get("compression").(bool)
+
+	var storage jetstream.StorageType
+	switch d.Get("storage").(string) {
+	case "file":
+		storage = jetstream.FileStorage
+	case "memory":
+		storage = jetstream.MemoryStorage
+	}
+
+	var placement *jetstream.Placement
+	c, ok := d.GetOk("placement_cluster")
+	if ok {
+		placement = &jetstream.Placement{Cluster: c.(string)}
+		pt, ok := d.GetOk("placement_tags")
+		if ok {
+			ts := pt.([]any)
+			var tags = make([]string, len(ts))
+			for i, tag := range ts {
+				tags[i] = tag.(string)
+			}
+			placement.Tags = tags
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return err
+	}
+
+	known, err := js.ObjectStore(ctx, name)
+	if known != nil {
+		return fmt.Errorf("bucket %s already exist", name)
+	} else if err != nil {
+		if !errors.Is(err, jetstream.ErrBucketNotFound) {
+			return fmt.Errorf("failed to load object store bucket: %s", err)
+		}
+	}
+
+	_, err = js.CreateObjectStore(ctx, jetstream.ObjectStoreConfig{
+		Bucket:      name,
+		Description: description,
+		TTL:         time.Duration(ttl) * time.Second,
+		MaxBytes:    int64(maxB),
+		Storage:     storage,
+		Replicas:    replicas,
+		Placement:   placement,
+		Compression: compression,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("JETSTREAM_OBJ_%s", name))
+
+	return resourceObjBucketRead(d, m)
+}
+
+func resourceObjBucketRead(d *schema.ResourceData, m any) error {
+	name, err := parseStreamObjID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	nc, err := getConnection(d, m)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return err
+	}
+
+	bucket, err := js.ObjectStore(ctx, name)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrBucketNotFound) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+	status, err := bucket.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", status.Bucket())
+	d.Set("description", status.Description())
+	d.Set("ttl", status.TTL().Seconds())
+	d.Set("replicas", status.Replicas())
+	d.Set("compression", status.IsCompressed())
+
+	switch status.Storage() {
+	case jetstream.FileStorage:
+		d.Set("storage", "file")
+	case jetstream.MemoryStorage:
+		d.Set("storage", "memory")
+	}
+
+	oStatus := status.(*jetstream.ObjectBucketStatus)
+	si := oStatus.StreamInfo()
+
+	d.Set("max_bucket_size", si.Config.MaxBytes)
+
+	if si.Config.Placement != nil {
+		d.Set("placement_cluster", si.Config.Placement.Cluster)
+		d.Set("placement_tags", si.Config.Placement.Tags)
+	}
+
+	return nil
+}
+
+func resourceObjBucketUpdate(d *schema.ResourceData, m any) error {
+	name := d.Get("name").(string)
+
+	nc, err := getConnection(d, m)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return err
+	}
+	bucket, err := js.ObjectStore(ctx, name)
+	if err != nil {
+		return err
+	}
+	status, err := bucket.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	oStatus := status.(*jetstream.ObjectBucketStatus)
+
+	str, err := js.Stream(ctx, oStatus.StreamInfo().Config.Name)
+	if err != nil {
+		return err
+	}
+
+	cfg := jetstream.ObjectStoreConfig{
+		Bucket:      name,
+		Description: str.CachedInfo().Config.Description,
+		TTL:         status.TTL(),
+		MaxBytes:    str.CachedInfo().Config.MaxBytes,
+		Storage:     str.CachedInfo().Config.Storage,
+		Replicas:    str.CachedInfo().Config.Replicas,
+		Placement:   str.CachedInfo().Config.Placement,
+		Compression: status.IsCompressed(),
+		Metadata:    str.CachedInfo().Config.Metadata,
+	}
+
+	ttl := d.Get("ttl").(int)
+	maxB := d.Get("max_bucket_size").(int)
+	replicas := d.Get("replicas").(int)
+	description := d.Get("description").(string)
+	compression := d.Get("compression").(bool)
+
+	cfg.TTL = time.Duration(ttl) * time.Second
+	cfg.MaxBytes = int64(maxB)
+	cfg.Replicas = replicas
+	cfg.Description = description
+	cfg.Compression = compression
+
+	_, err = js.CreateOrUpdateObjectStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+
+	return resourceObjBucketRead(d, m)
+}
+
+func resourceObjBucketDelete(d *schema.ResourceData, m any) error {
+	name := d.Get("name").(string)
+
+	nc, err := getConnection(d, m)
+	if err != nil {
+		return err
+	}
+	defer nc.Close()
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = js.DeleteObjectStore(ctx, name)
+	if errors.Is(err, jetstream.ErrBucketNotFound) || errors.Is(err, nats.ErrStreamNotFound) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/jetstream/resource_obj_bucket_test.go
+++ b/jetstream/resource_obj_bucket_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jetstream
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/nats-io/jsm.go"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const testObj_basic = `
+provider "jetstream" {
+  servers = "%s"
+}
+
+resource "jetstream_obj_bucket" "test" {
+  name = "TEST"
+  ttl = 60
+  storage = "memory"
+  max_bucket_size = 10240
+  compression = true
+}
+`
+
+func TestResourceObj(t *testing.T) {
+	srv := createJSServer(t)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	defer nc.Close()
+
+	mgr, err := jsm.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testJsProviders,
+		CheckDestroy:      testObjBucketDoesNotExist(t, mgr, "TEST"),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testObj_basic, nc.ConnectedUrl()),
+				Check: resource.ComposeTestCheckFunc(
+					testObjBucketExist(t, mgr, "TEST"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "name", "TEST"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "ttl", "60"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "storage", "memory"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "max_bucket_size", "10240"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "compression", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testObjBucketDoesNotExist(t *testing.T, mgr *jsm.Manager, bucket string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err := testObjBucketExist(t, mgr, bucket)
+		if err == nil {
+			return fmt.Errorf("expected bucket %q to not exist", bucket)
+		}
+
+		return nil
+	}
+}
+
+func testObjBucketExist(t *testing.T, mgr *jsm.Manager, bucket string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		known, err := mgr.IsKnownStream("OBJ_" + bucket)
+		if err != nil {
+			return err
+		}
+
+		if !known {
+			return fmt.Errorf("bucket %s does not exist", bucket)
+		}
+
+		return nil
+	}
+}
+
+func TestResourceObjExternalDeletion(t *testing.T) {
+	srv := createJSServer(t)
+	defer srv.Shutdown()
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	defer nc.Close()
+
+	mgr, err := jsm.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("could not connect: %s", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testJsProviders,
+		CheckDestroy:      testObjBucketDoesNotExist(t, mgr, "TEST"),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testObj_basic, nc.ConnectedUrl()),
+				Check: resource.ComposeTestCheckFunc(
+					testObjBucketExist(t, mgr, "TEST"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "name", "TEST"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(testObj_basic, nc.ConnectedUrl()),
+				PreConfig: func() {
+					err := js.DeleteObjectStore(ctx, "TEST")
+					if err != nil {
+						t.Fatalf("failed to externally delete bucket: %s", err)
+					}
+				},
+				Check: resource.ComposeTestCheckFunc(
+					testObjBucketExist(t, mgr, "TEST"),
+					resource.TestCheckResourceAttr("jetstream_obj_bucket.test", "name", "TEST"),
+				),
+			},
+		},
+	})
+}

--- a/jetstream/util.go
+++ b/jetstream/util.go
@@ -36,6 +36,15 @@ var (
 	connectMu sync.Mutex
 )
 
+func parseStreamObjID(id string) (string, error) {
+	if !objIdRegex.MatchString(id) {
+		return "", fmt.Errorf("invalid object store bucket id %q", id)
+	}
+
+	matches := objIdRegex.FindStringSubmatch(id)
+	return matches[1], nil
+}
+
 func parseStreamKVEntryID(id string) (bucket string, key string, err error) {
 	if !kvEntryIdRegex.MatchString(id) {
 		return "", "", fmt.Errorf("invalid kv entry id %q", id)


### PR DESCRIPTION
### Description

Resolves #180 

### Changes

* Add `resource_obj_bucket.go` that implements the NATS Object Store Bucket resource; analogous to `resource_kv_bucket.go`.
* Add analogous tests, docs, and update README to include the new resource.

### Comments

* Tests are passing; with `TF_ACC`.
* Lints are passing (defined in `ABTaskFile`).
* Some manual testing using the local `jetstream` provider on a local NATS cluster looks ok. Lmk if there's a protocol to adhere to wrt. verification.
* This is more or less a translation of the KV-bucket resource, with some implications that we may want to address:
  * There are some duplicate code fragments.
  * Object Store buckets support metadata (as regular streams); but this is not exposed as a resource field (similar to the KV-bucket).
  * Placement and storage type is not considered for resource _updates_ (similar to the KV-bucket).